### PR TITLE
Fix kinematic plugin when use_sim_time = true

### DIFF
--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -388,7 +388,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
       const kinematics::KinematicsQueryOptions &options =
           kinematics::KinematicsQueryOptions(),
       const moveit::core::RobotState *context_state = NULL) const override {
-    double t0 = node_->now().seconds();
+    double t0 = rclcpp::Clock().now().seconds();
 
     // timeout = 0.1;
 


### PR DESCRIPTION
Currently the IK will fail if it is called from a node that has the parmaeter "use_sim_time" = true
This is due to once using ROS_TIME while everything else uses SYSTEM_TIME. Fixed this and now it works also in simulation.